### PR TITLE
Fix switch provider

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -440,7 +440,7 @@ sub migrate {
         my $original_id = $original_request->illrequest_id;
         my @original_attributes = $original_request->illrequestattributes->search(
             { illrequest_id => $original_id }
-        );
+        )->as_list;
         my @attributes = keys %{$fields};
 
         # Look for an equivalent Rapid attribute 


### PR DESCRIPTION
Without this, attempting to switch from FreeForm to RapidILL would result in the error: The method Koha::Illrequestattributes->type is not covered by tests!

RT #47457